### PR TITLE
Update GH actions, repository links, package names

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -8,9 +8,9 @@ defaults:
       bash
 jobs:
   build-sdist:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Verify tag matches version
         run: |
           set -ex
@@ -19,7 +19,7 @@ jobs:
           if [[ "$version" != "$tag" ]]; then
             exit 1
           fi
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           python-version: 3.9
       - run: |
@@ -28,18 +28,18 @@ jobs:
           python -m build
       - run: |
           pip install dist/*.tar.gz
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: sdist
           path: dist/*.tar.gz
   build-wheels:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - run: |
@@ -48,53 +48,46 @@ jobs:
           python -m build
       - run: |
           python -m pip install dist/*.whl
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: wheel-${{ matrix.python-version }}
           path: dist/*.whl
   publish-artifacts:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [build-sdist, build-wheels]
+    environment:
+      name: release
+      url: https://pypi.org/p/coqui-tts-trainer
+    permissions:
+      id-token: write
     steps:
       - run: |
           mkdir dist
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: "sdist"
           path: "dist/"
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: "wheel-3.8"
           path: "dist/"
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: "wheel-3.9"
           path: "dist/"
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: "wheel-3.10"
           path: "dist/"
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: "wheel-3.11"
           path: "dist/"
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: "wheel-3.12"
           path: "dist/"
       - run: |
           ls -lh dist/
-      - name: Setup PyPI config
-        run: |
-          cat << EOF > ~/.pypirc
-          [pypi]
-          username=__token__
-          password=${{ secrets.PYPI_TOKEN }}
-          EOF
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      - run: |
-          python -m pip install twine
-      - run: |
-          twine upload --repository pypi dist/*
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -7,23 +7,16 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
-  check_skip:
-    runs-on: ubuntu-latest
-    if: "! contains(github.event.head_commit.message, '[ci skip]')"
-    steps:
-      - run: echo "${{ github.event.head_commit.message }}"
-
   test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python-version: [3.9]
-        experimental: [false]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,23 +7,16 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
-  check_skip:
-    runs-on: ubuntu-latest
-    if: "! contains(github.event.head_commit.message, '[ci skip]')"
-    steps:
-      - run: echo "${{ github.event.head_commit.message }}"
-
   test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
-        experimental: [false]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses:  actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Welcome to the 👟!
 
-This repository is governed by [the Contributor Covenant Code of Conduct](https://github.com/coqui-ai/Trainer/blob/main/CODE_OF_CONDUCT.md).
+This repository is governed by [the Contributor Covenant Code of Conduct](https://github.com/eginhard/coqui-trainer/blob/main/CODE_OF_CONDUCT.md).
 
 ## Where to start.
 We welcome everyone who likes to contribute to 👟.
@@ -11,13 +11,13 @@ You can contribute not only with code but with bug reports, comments, questions,
 
 If you like to contribute code, squash a bug but if you don't know where to start, here are some pointers.
 
-- [Github Issues Tracker](https://github.com/coqui-ai/Trainer/issues)
+- [Github Issues Tracker](https://github.com/eginhard/coqui-trainer/issues)
 
     This is a place to find feature requests, bugs.
 
     Issues with the ```good first issue``` tag are good place for beginners to take on.
 
-- ✨**PR**✨ [pages](https://github.com/coqui-ai/Trainer/pulls) with the ```🚀new version``` tag.
+- ✨**PR**✨ [pages](https://github.com/eginhard/coqui-trainer/pulls) with the ```🚀new version``` tag.
 
     We list all the target improvements for the next version. You can pick one of them and start contributing.
 
@@ -31,14 +31,14 @@ Let us know if you encounter a problem along the way.
 
 The following steps are tested on an Ubuntu system.
 
-1. Fork 👟[https://github.com/coqui-ai/Trainer] by clicking the fork button at the top right corner of the project page.
+1. Fork 👟[https://github.com/eginhard/coqui-trainer] by clicking the fork button at the top right corner of the project page.
 
 2. Clone 👟 and add the main repo as a new remote named ```upsteam```.
 
     ```bash
-    $ git clone git@github.com:<your Github name>/Trainer.git
-    $ cd Trainer
-    $ git remote add upstream https://github.com/coqui-ai/Trainer.git
+    $ git clone git@github.com:<your Github name>/coqui-trainer.git
+    $ cd coqui-trainer
+    $ git remote add upstream https://github.com/eginhard/coqui-trainer.git
     ```
 
 3. Install 👟 for development.
@@ -89,12 +89,10 @@ The following steps are tested on an Ubuntu system.
 
     ```bash
     $ git fetch upstream
-    $ git rebase upstream/master
-    # or for the development version
-    $ git rebase upstream/dev
+    $ git rebase upstream/main
     ```
 
-12. Send a PR to ```dev``` branch.
+12. Send a PR to ```main``` branch.
 
     Push your branch to your fork.
 
@@ -104,13 +102,11 @@ The following steps are tested on an Ubuntu system.
 
     Then go to your fork's Github page and click on 'Pull request' to send your ✨**PR**✨.
 
-    Please set ✨**PR**✨'s target branch to ```dev``` as we use ```dev``` to work on the next version.
-
 13. Let's discuss until it is perfect. 💪
 
-    We might ask you for certain changes that would appear in the ✨**PR**✨'s page under 👟[https://github.com/coqui-ai/Trainer/pulls].
+    We might ask you for certain changes that would appear in the ✨**PR**✨'s page under 👟[https://github.com/eginhard/coqui-trainer/pulls].
 
-14. Once things look perfect, We merge it to the ```dev``` branch and make it ready for the next version.
+14. Once things look perfect, We merge it to the ```main``` branch and make it ready for the next version.
 
 Feel free to ping us at any step you need help using our communication channels.
 

--- a/README.md
+++ b/README.md
@@ -8,18 +8,16 @@ An opinionated general purpose model trainer on PyTorch with a simple code base.
 From Github:
 
 ```console
-git clone https://github.com/coqui-ai/Trainer
-cd Trainer
+git clone https://github.com/eginhard/coqui-trainer
+cd coqui-trainer
 make install
 ```
 
 From PyPI:
 
 ```console
-pip install trainer
+pip install coqui-tts-trainer
 ```
-
-Prefer installing from Github as it is more stable.
 
 ## Implementing a model
 Subclass and overload the functions in the [```TrainerModel()```](trainer/model.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 torch>=1.7
-torchvision
 coqpit
 psutil
 fsspec

--- a/setup.py
+++ b/setup.py
@@ -72,11 +72,13 @@ with open("README.md", "r", encoding="utf-8") as readme_file:
     README = readme_file.read()
 
 setup(
-    name="trainer",
+    name="coqui-tts-trainer",
     version=version,
-    url="https://github.com/coqui-ai/Trainer",
+    url="https://github.com/eginhard/coqui-trainer",
     author="Eren Gölge",
     author_email="egolge@coqui.ai",
+    maintainer="Enno Hermann",
+    maintainer_email="enno.hermann@gmail.com",
     description="General purpose model trainer for PyTorch that is more flexible than it should be, by 🐸Coqui.",
     long_description=README,
     long_description_content_type="text/markdown",
@@ -90,10 +92,10 @@ setup(
         ]
     },
     project_urls={
-        "Documentation": "https://github.com/coqui-ai/Trainer/",
-        "Tracker": "https://github.com/coqui-ai/Trainer/issues",
-        "Repository": "https://github.com/coqui-ai/Trainer",
-        "Discussions": "https://github.com/coqui-ai/Trainer/discussions",
+        "Documentation": "https://github.com/eginhard/coqui-trainer",
+        "Tracker": "https://github.com/eginhard/coqui-trainer/issues",
+        "Repository": "https://github.com/eginhard/coqui-trainer",
+        "Discussions": "https://github.com/eginhard/coqui-trainer/discussions",
     },
     cmdclass={
         "build_py": build_py,


### PR DESCRIPTION
- replace references to https://github.com/coqui-ai/Trainer with this repository
- prepare for release as `coqui-tts-trainer` package

